### PR TITLE
FB3対応

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,11 +3,11 @@
 class UsersController < ApplicationController
 
   def show
-    @worries = current_user.worries.where(page: "トップ")
+    @worries = current_user.worries.where(page: "トップ").order(updated_at: :desc)
   end
 
   def temp
-    @worries = current_user.worries.where(page: "一時")
+    @worries = current_user.worries.where(page: "一時").order(updated_at: :desc)
     render :show
   end
 


### PR DESCRIPTION
#What
FB3：投稿一覧機能・一時フォルダ機能のお悩みの並び順の変更

#Why
お悩みの並び順が、古いものが先に表示さるようになっている
→新しいものが上にくるようにしました。


