### PR TITLE
FB5対応

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,5 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable
   has_many :worries
+  validates :name, presence: true
 end


### PR DESCRIPTION
#Whta
 ユーザー名にバリデーションを設定

#Why
新規登録時にユーザー名が空欄でも登録できてしまうため