### PR TITLE
FB6対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,3 +77,4 @@ gem 'devise'
 gem "hotwire-rails", "~> 0.1.3"
 # gem 'rails-ujs'
 gem 'httparty'
+gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
@@ -145,6 +146,11 @@ GEM
     nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     psych (5.1.1.1)
       stringio
     public_suffix (5.0.3)
@@ -247,6 +253,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   mysql2 (~> 0.5)
+  pry-rails
   puma (~> 5.0)
   rails (~> 7.0.0)
   selenium-webdriver

--- a/app/controllers/worries_controller.rb
+++ b/app/controllers/worries_controller.rb
@@ -14,8 +14,8 @@ class WorriesController < ApplicationController
     @worry = Worry.new(worry_params)
     @worry.page = 'トップ'
     
-    # 画像が添付されていない場合、デフォルトの画像を添付する
-    unless @worry.image.attached?
+    # 画像が添付されていないかつテキストが存在する場合、デフォルトの画像を添付
+    if !@worry.image.attached? && @worry.text.present?
       @worry.image.attach(io: File.open(Rails.root.join('app', 'assets', 'images', 'no_image.png')), filename: 'no_image.png', content_type: 'image/png')
     end
     

--- a/app/models/worry.rb
+++ b/app/models/worry.rb
@@ -8,4 +8,15 @@ class Worry < ApplicationRecord
     days_passed = (Time.now - updated_at).to_i / 1.day
     [1 - 0.1 * days_passed, 0.1].max
   end
+
+  validate :must_have_image_or_text
+
+  private
+
+  def must_have_image_or_text
+    if !image.attached? && text.blank?
+      errors.add(:base, "画像またはテキストのどちらかを入力してください。")
+    end
+  end
+  
 end


### PR DESCRIPTION
#What
■FB6：お悩みは、画像・テキストのどちらかがないと投稿できないようにする

#Why
画像もテキストもない場合に投稿できる状態であり、両方とも空で投稿ボタンを押すと、不要な空データができ上がってしまうため

