### PR TITLE
FB7対応

### DIFF
--- a/app/controllers/worries_controller.rb
+++ b/app/controllers/worries_controller.rb
@@ -41,6 +41,12 @@ class WorriesController < ApplicationController
 
   def edit
     @worry = Worry.find(params[:id])
+    
+    unless @worry.user == current_user
+      redirect_to user_path(current_user), alert: '他のユーザーのお悩みを編集することはできません。'
+      return
+    end
+  
     @from_temp_page = request.referer&.include?(temp_page_path)
   end
 


### PR DESCRIPTION
#What
■FB7：URL指定で、他の人のお悩みが編集できないようにする

#Why
URL指定で、他の人のお悩みが編集できてしまいまうため