### PR TITLE
FB8対応

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -36,7 +36,7 @@
 }
 
 .worries-list {
-  margin-top: 200px;
+  margin-top: 300px;
   display: flex;
   flex-wrap: wrap;
   gap: 50px;
@@ -86,6 +86,7 @@
   text-decoration: none;
   cursor: pointer;
   transition: background-color 0.3s;
+  text-align: center;
 }
 
 
@@ -95,7 +96,7 @@
   margin:5px;
   display: inline-block;
   padding: 15px 20px 7px 20px;       /* 必要に応じて調整 */
-  width: 130px;             /* ボタンの幅 */
+  width: 128px;             /* ボタンの幅 */
   height: 18px;             /* ボタンの高さ */
   line-height: 10px;        /* テキストの垂直位置を調整 */
   font-size: 14px;          /* フォントサイズを設定 */
@@ -106,6 +107,7 @@
   text-decoration: none;
   cursor: pointer;
   transition: background-color 0.3s;
+  text-align: center;
 }
 
 
@@ -115,7 +117,7 @@
   margin:5px;
   display: inline-block;
   padding: 15px 20px 7px 20px;       /* 必要に応じて調整 */
-  width: 130px;             /* ボタンの幅 */
+  width: 128px;             /* ボタンの幅 */
   height: 18px;             /* ボタンの高さ */
   line-height: 10px;        /* テキストの垂直位置を調整 */
   font-size: 14px;          /* フォントサイズを設定 */
@@ -126,6 +128,7 @@
   text-decoration: none;
   cursor: pointer;
   transition: background-color 0.3s;
+  text-align: center;
 }
 
 
@@ -135,7 +138,7 @@
   margin:5px;
   display: inline-block;
   padding: 15px 20px 7px 20px;       /* 必要に応じて調整 */
-  width: 130px;             /* ボタンの幅 */
+  width: 128px;             /* ボタンの幅 */
   height: 18px;             /* ボタンの高さ */
   line-height: 10px;        /* テキストの垂直位置を調整 */
   font-size: 14px;          /* フォントサイズを設定 */
@@ -146,6 +149,7 @@
   text-decoration: none;
   cursor: pointer;
   transition: background-color 0.3s;
+  text-align: center;
 }
 
 
@@ -166,6 +170,7 @@
   text-decoration: none;
   cursor: pointer;
   transition: background-color 0.3s;
+  text-align: center;
 }
 
 
@@ -186,6 +191,7 @@
   text-decoration: none;
   cursor: pointer;
   transition: background-color 0.3s;
+  text-align: center;
 }
 
 
@@ -206,6 +212,7 @@
   text-decoration: none;
   cursor: pointer;
   transition: background-color 0.3s;
+  text-align: center;
 }
 
 
@@ -226,5 +233,14 @@
   text-decoration: none;
   cursor: pointer;
   transition: background-color 0.3s;
+  text-align: center;
 }
 
+.header-buttons {
+  text-align: right;
+  display: inline-block;
+}
+
+.header-row {
+  margin-bottom: 10px;
+}

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,14 +6,23 @@
   <%= form_with(url: move_to_temp_worries_path, method: :post) do %>
     <div class="header">
       <h1><%= current_user.name %> さんのページ</h1>
-      <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "btn-standard3" %>
-      <%# <br> %>
-      <%= link_to "一時フォルダページ", temp_page_path, class: "btn-standard4" %>
-      <%= link_to "お悩み投稿", new_worry_path, class: "btn-standard5" %>
-      <%# <br> %>
-      <%= submit_tag 'データ削除', class: "btn-standard6" %>
-      <%= submit_tag "一時フォルダへ移動", class: "btn-standard7" %>
-      <%= submit_tag "編集", name: 'edit', value: '編集', class: "btn-standard8" %>
+
+
+      <div class="header-buttons">
+        <div class="header-row">
+          <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "btn-standard3" %>
+          <%= link_to "一時フォルダページ", temp_page_path, class: "btn-standard4" %>
+          <%= link_to "お悩み投稿", new_worry_path, class: "btn-standard5" %>
+        </div>
+
+
+        <div class="header-row">
+          <%= submit_tag 'データ削除', class: "btn-standard6" %>
+          <%= submit_tag "一時フォルダへ移動", class: "btn-standard7" %>
+          <%= submit_tag "編集", name: 'edit', value: '編集', class: "btn-standard8" %>
+        </div>
+
+      </div>
     </div>
     <div class="worries-list">
       <% @worries.each do |worry| %>
@@ -34,16 +43,22 @@
   <%= form_with(url: move_from_temp_worries_path, method: :post) do %>
     <div class="header">
       <h1>一時ページ</h1>
-      <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "btn-standard3" %>
-      <%# <%= link_to "#{current_user.name}さんのページ", user_path(current_user), class: "btn-standard" %>
-      <%# <br> %>
-      <%= link_to "ユーザーページ", user_path(current_user), class: "btn-standard4" %>      
-      <%= link_to "お悩み投稿", new_worry_path, class: "btn-standard5" %>
-      <%# <br> %>
-      <%= submit_tag 'データ削除', class: "btn-standard6" %>
-      <%# <%= submit_tag "#{current_user.name}さんのページに戻す", class: "btn-standard" %>
-      <%= submit_tag "ユーザーページに戻す", class: "btn-standard7" %>
-      <%= submit_tag "編集", name: 'edit', value: '編集', class: "btn-standard8" %>
+
+
+      <div class="header-buttons">
+        <div class="header-row">
+          <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "btn-standard3" %>
+          <%= link_to "ユーザーページ", user_path(current_user), class: "btn-standard4" %>      
+          <%= link_to "お悩み投稿", new_worry_path, class: "btn-standard5" %>
+        </div>
+
+        <div class="header-row">
+          <%= submit_tag 'データ削除', class: "btn-standard6" %>
+          <%= submit_tag "ユーザーページに戻す", class: "btn-standard7" %>
+          <%= submit_tag "編集", name: 'edit', value: '編集', class: "btn-standard8" %>
+        </div>
+      </div>
+
     </div>
     <div class="worries-list">
       <% @worries.each do |worry| %>


### PR DESCRIPTION
#What
FB8：ヘッダーに並んでいるボタンの並びを修正

#Why
マイページ・一時ページのヘッダーに並んでいるボタンの判断が難しいため
（どのボタンを押せば何ができるのかがわかりづらいため）
あまり縦方向を占有したくなかったので2段にしました。

