### PR TITLE
一時フォルダページボタンの修正

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,7 +11,7 @@
         <div class="header-buttons">
           <div class="header-row">
             <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "btn-standard3" %>
-            <%= link_to "一時フォルダページ", temp_page_path, class: "btn-standard4" %>
+            <%= link_to "一時フォルダ", temp_page_path, class: "btn-standard4" %>
             <%= link_to "お悩み投稿", new_worry_path, class: "btn-standard5" %>
           </div>
 


### PR DESCRIPTION
# What
「一時フォルダページ」ボタンと「一時フォルダへ移動」ボタンが分かりずらいです。

# Why
「一時フォルダページ」ボタンを「一時フォルダ」ボタンに修正しました。

https://gyazo.com/e1e08bb1676b55521507366ad67ab710